### PR TITLE
Use json instead of django simplejson (depreciated)

### DIFF
--- a/rest_hooks/models.py
+++ b/rest_hooks/models.py
@@ -1,9 +1,15 @@
 import requests
 
 from django.conf import settings
-from django.core import serializers, exceptions
+from django.core import serializers
 from django.db import models
-from django.utils import simplejson as json
+
+try:
+    # Django <= 1.6 backwards compatibility
+    from django.utils import simplejson as json
+except ImportError:
+    # Django >= 1.7
+    import json
 
 from rest_hooks.utils import get_module, find_and_fire_hook, distill_model_event
 
@@ -21,6 +27,7 @@ else:
     client = requests
 
 AUTH_USER_MODEL = getattr(settings, 'AUTH_USER_MODEL', 'auth.User')
+
 
 class Hook(models.Model):
     """
@@ -78,7 +85,6 @@ class Hook(models.Model):
 
         signals.hook_sent_event.send_robust(sender=self.__class__, payload=payload, instance=instance, hook=self)
         return None
-
 
     def __unicode__(self):
         return u'{} => {}'.format(self.event, self.target)

--- a/rest_hooks/tests.py
+++ b/rest_hooks/tests.py
@@ -4,12 +4,18 @@ from mock import patch, MagicMock, ANY
 
 from datetime import datetime
 
+try:
+    # Django <= 1.6 backwards compatibility
+    from django.utils import simplejson as json
+except ImportError:
+    # Django >= 1.7
+    import json
+
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.contrib.comments.models import Comment
 from django.contrib.sites.models import Site
 from django.test import TestCase
-from django.utils import simplejson as json
 
 from rest_hooks import models
 Hook = models.Hook


### PR DESCRIPTION
Hi there, thank you for this great lib.

I just wanted to suggest to switch from the `django.utils.simplejson` to the `json` module as the first one will be depreciated from Django 1.7 (and raises annoying warnings in 1.6) and is not really useful anymore since Python 2.7.