### PR TITLE
Added support for python 3 and django 1.8.

### DIFF
--- a/devrequirements.txt
+++ b/devrequirements.txt
@@ -1,3 +1,4 @@
-Django==1.4.6
+Django==1.8
+-e git+git@github.com:meric/django-contrib-comments.git@0a4aa7278decb5c388b02f01f11b1512562852bf#egg=django_comments
 requests==1.2.3
 mock==1.0.1

--- a/devrequirements.txt
+++ b/devrequirements.txt
@@ -1,4 +1,4 @@
 Django==1.8
--e git+git@github.com:meric/django-contrib-comments.git@0a4aa7278decb5c388b02f01f11b1512562852bf#egg=django_comments
+-e git+git@github.com:django/django-contrib-comments.git@07affdeed8bfce34761c6611573fe6ccce2c9f61#egg=django_contrib_comments-origin/HEAD
 requests==1.2.3
 mock==1.0.1

--- a/rest_hooks/tests.py
+++ b/rest_hooks/tests.py
@@ -13,7 +13,7 @@ except ImportError:
 
 from django.conf import settings
 from django.contrib.auth.models import User
-from django.contrib.comments.models import Comment
+from django_comments.models import Comment
 from django.contrib.sites.models import Site
 from django.test import TestCase
 
@@ -42,10 +42,10 @@ class RESTHooksTest(TestCase):
         self.site = Site.objects.create(domain='example.com', name='example.com')
 
         models.HOOK_EVENTS = {
-            'comment.added':        'comments.Comment.created',
-            'comment.changed':      'comments.Comment.updated',
-            'comment.removed':      'comments.Comment.deleted',
-            'comment.moderated':    'comments.Comment.moderated',
+            'comment.added':        'django_comments.Comment.created',
+            'comment.changed':      'django_comments.Comment.updated',
+            'comment.removed':      'django_comments.Comment.deleted',
+            'comment.moderated':    'django_comments.Comment.moderated',
             'special.thing':        None
         }
 
@@ -240,13 +240,13 @@ class RESTHooksTest(TestCase):
                 comment.delete()
             total = datetime.now() - early
 
-            print total
+            print(total)
 
             while True:
                 response = requests.get(target + '/view')
                 sent = response.json
                 if sent:
-                    print len(sent), models.async_requests.total_sent
+                    print(len(sent), models.async_requests.total_sent)
                 if models.async_requests.total_sent >= (30 * (n+1)):
                     time.sleep(5)
                     break

--- a/rest_hooks/utils.py
+++ b/rest_hooks/utils.py
@@ -10,7 +10,7 @@ def get_module(path):
     try:
         mod_name, func_name = path.rsplit('.', 1)
         mod = import_module(mod_name)
-    except ImportError, e:
+    except ImportError as e:
         raise ImportError(
             'Error importing alert function {0}: "{1}"'.format(mod_name, e))
 

--- a/runtests.py
+++ b/runtests.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python
 
 import sys
+import django
+
 from django.conf import settings
+from django.apps import apps
 
 
 APP_NAME = 'rest_hooks'
@@ -28,10 +31,13 @@ settings.configure(
         'django.contrib.sessions',
         'django.contrib.admin',
         'django.contrib.sites',
-        'django.contrib.comments',
+        'django_comments',
         APP_NAME,
     ),
 )
+
+if hasattr(django, 'setup'):
+    django.setup()
 
 from django.test.utils import get_runner
 TestRunner = get_runner(settings)


### PR DESCRIPTION
Updated `django-rest-hooks` for django 1.8. Retained the use of `django.contrib.comments` in unit tests even though it's been released in django 1.8; `django.contrib.comments` now available as a separate module.

There is an caveat being it now relies on my fork of `django.contrib.comments` since it doesn't inherently support Django 1.8 (while retaining support for older django versions) and needed to be updated, too.
