### PR TITLE
Update async delivery instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Travis CI Build](https://img.shields.io/travis/zapier/django-rest-hooks/master.svg)](https://travis-ci.org/zapier/django-rest-hooks)
 [![PyPI Download](https://img.shields.io/pypi/v/django-rest-hooks.svg)](https://pypi.python.org/pypi/django-rest-hooks)
 [![PyPI Status](https://img.shields.io/pypi/status/django-rest-hooks.svg)](https://pypi.python.org/pypi/django-rest-hooks)
-## What are Django REST Hooks? 
+## What are Django REST Hooks?
 
 
 REST Hooks are fancier versions of webhooks. Traditional webhooks are usually
@@ -361,12 +361,12 @@ import requests
 
 
 class DeliverHook(Task):
-    def run(self, target, payload, instance=None, hook=None, **kwargs):
+    def run(self, target, payload, instance_id=None, hook_id=None, **kwargs):
         """
         target:     the url to receive the payload.
         payload:    a python primitive data structure
-        instance:   a possibly null "trigger" instance
-        hook:       the defining Hook object
+        instance_id:   a possibly None "trigger" instance ID
+        hook_id:       the ID of defining Hook object
         """
         requests.post(
             url=target,
@@ -374,7 +374,18 @@ class DeliverHook(Task):
             headers={'Content-Type': 'application/json'}
         )
 
-deliver_hook_wrapper = DeliverHook.delay
+
+def deliver_hook_wrapper(target, payload, instance, hook):
+    # instance is None if using custom event, not built-in
+    if instance is not None:
+        instance_id = instance.id
+    else:
+        instance_id = None
+    # pass ID's not objects because using pickle for objects is a bad thing
+    kwargs = dict(target=target, payload=payload,
+                  instance_id=instance_id, hook_id=hook.id)
+    DeliverHook.apply_async(kwargs=kwargs)
+
 ```
 
 We also don't handle retries or cleanup. Generally, if you get a `410` or


### PR DESCRIPTION
To provide better guidance to allow for JSON encoding of tasks
As per https://github.com/zapier/django-rest-hooks/issues/24