### PR TITLE
Fix for migration issue #27

### DIFF
--- a/rest_hooks/admin.py
+++ b/rest_hooks/admin.py
@@ -1,9 +1,25 @@
 from django.contrib import admin
-
+from django.conf import settings
+from django import forms
 from rest_hooks.models import Hook
+
+
+HOOK_EVENTS = getattr(settings, 'HOOK_EVENTS', None)
+if HOOK_EVENTS is None:
+    raise Exception("You need to define settings.HOOK_EVENTS!")
+
+
+class HookForm(forms.ModelForm):
+    ADMIN_EVENTS = [(x, x) for x in HOOK_EVENTS.keys()]
+
+    def __init__(self, *args, **kwargs):
+        super(HookForm, self).__init__(*args, **kwargs)
+        self.fields['event'] = forms.ChoiceField(choices=self.ADMIN_EVENTS)
 
 
 class HookAdmin(admin.ModelAdmin):
     list_display = [f.name for f in Hook._meta.fields]
-    raw_id_fields = ['user',]
+    raw_id_fields = ['user', ]
+    form = HookForm
+
 admin.site.register(Hook, HookAdmin)

--- a/rest_hooks/migrations/0001_initial.py
+++ b/rest_hooks/migrations/0001_initial.py
@@ -18,8 +18,8 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('created', models.DateTimeField(auto_now_add=True)),
                 ('updated', models.DateTimeField(auto_now=True)),
-                ('event', models.CharField(max_length=64, verbose_name=b'Event', db_index=True)),
-                ('target', models.URLField(max_length=255, verbose_name=b'Target URL')),
+                ('event', models.CharField(max_length=64, verbose_name='Event', db_index=True)),
+                ('target', models.URLField(max_length=255, verbose_name='Target URL')),
                 ('user', models.ForeignKey(related_name='hooks', to=settings.AUTH_USER_MODEL)),
             ],
             options={

--- a/rest_hooks/models.py
+++ b/rest_hooks/models.py
@@ -2,6 +2,7 @@ from collections import OrderedDict
 
 import requests
 
+from django.core.exceptions import ValidationError
 from django.conf import settings
 from django.core import serializers
 from django.db import models
@@ -40,9 +41,15 @@ class Hook(models.Model):
 
     user = models.ForeignKey(AUTH_USER_MODEL, related_name='hooks')
     event = models.CharField('Event', max_length=64,
-                                      db_index=True,
-                                      choices=[(e, e) for e in HOOK_EVENTS.keys()])
+                                      db_index=True)
     target = models.URLField('Target URL', max_length=255)
+
+    def clean(self):
+        """ Validation for events. """
+        if self.event not in HOOK_EVENTS.keys():
+            raise ValidationError(
+                "Invalid hook event {evt}.".format(self.event)
+            )
 
     def dict(self):
         return {


### PR DESCRIPTION
Refactored the Hook model to not enforce django migrations each time you need to create new events on HOOK_EVENTS.

Added the django admin form widget as required . Fixed the problem of generating new migrations after 0001 due to the literal byte notation that was genarated initially in python 2.7+ (please generate migrations using python3 once python2 just ignore the literal byte notation).

Solves the issue #27 