### PR TITLE
Added required additional documentation on README and admin.py files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,9 @@ handle the basic `created`, `updated` and `deleted` signals & events:
 ...
 ```
 
+> NOTE: If you try to register an invalid event hook (not listed on HOOK_EVENTS in settings.py)
+you will get a **ValidationError**.
+
 Now that the book has been created, `http://example.com/target.php` will get:
 
 ```

--- a/rest_hooks/admin.py
+++ b/rest_hooks/admin.py
@@ -10,6 +10,11 @@ if HOOK_EVENTS is None:
 
 
 class HookForm(forms.ModelForm):
+    """
+    Model form to handle registered events, asuring
+    only events declared on HOOK_EVENTS settings
+    can be registered.
+    """
     ADMIN_EVENTS = [(x, x) for x in HOOK_EVENTS.keys()]
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
It's self explanatory :)

Just added explicit documentation on README about the ValidationError docstring on Hook model admin form as requested by @avelis in #27.