### PR TITLE
Adjusted django-rest-framework instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,7 @@ class HookSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Hook
+        fields = '__all__'
         read_only_fields = ('user',)
 
 ### views.py ###
@@ -324,6 +325,7 @@ class HookViewSet(viewsets.ModelViewSet):
     """
     Retrieve, create, update or destroy webhooks.
     """
+    queryset = Hook.objects.all()
     model = Hook
     serializer_class = HookSerializer
 


### PR DESCRIPTION
Newer versions of django-rest-framework require an explicit `fields` property for the serializer and a `queryset` for the viewset.