### PR TITLE
allow configurable user / owner model

### DIFF
--- a/rest_hooks/admin.py
+++ b/rest_hooks/admin.py
@@ -4,11 +4,6 @@ from django import forms
 from rest_hooks.models import Hook
 
 
-AUTH_USER_MODEL = getattr(settings, 'AUTH_USER_MODEL', 'auth.User')
-OWNER_MODEL = getattr(settings, 'REST_HOOKS_OWNER_MODEL', AUTH_USER_MODEL)
-OWNER_FIELD_NAME = getattr(settings, 'REST_HOOKS_OWNER_FIELD_NAME', 'user')
-
-
 HOOK_EVENTS = getattr(settings, 'HOOK_EVENTS', None)
 if HOOK_EVENTS is None:
     raise Exception("You need to define settings.HOOK_EVENTS!")

--- a/rest_hooks/admin.py
+++ b/rest_hooks/admin.py
@@ -4,6 +4,11 @@ from django import forms
 from rest_hooks.models import Hook
 
 
+AUTH_USER_MODEL = getattr(settings, 'AUTH_USER_MODEL', 'auth.User')
+OWNER_MODEL = getattr(settings, 'REST_HOOKS_OWNER_MODEL', AUTH_USER_MODEL)
+OWNER_FIELD_NAME = getattr(settings, 'REST_HOOKS_OWNER_FIELD_NAME', 'user')
+
+
 HOOK_EVENTS = getattr(settings, 'HOOK_EVENTS', None)
 if HOOK_EVENTS is None:
     raise Exception("You need to define settings.HOOK_EVENTS!")

--- a/rest_hooks/models.py
+++ b/rest_hooks/models.py
@@ -15,7 +15,7 @@ except ImportError:
     # Django >= 1.7
     import json
 
-from rest_hooks.utils import get_module, find_and_fire_hook, distill_model_event
+from rest_hooks.utils import get_module, find_and_fire_hook, distill_model_event, OWNER_MODEL, OWNER_FIELD_NAME
 
 from rest_hooks import signals
 
@@ -29,10 +29,6 @@ if getattr(settings, 'HOOK_THREADING', True):
     client = Client()
 else:
     client = requests.Session()
-
-AUTH_USER_MODEL = getattr(settings, 'AUTH_USER_MODEL', 'auth.User')
-OWNER_MODEL = getattr(settings, 'REST_HOOKS_OWNER_MODEL', AUTH_USER_MODEL)
-OWNER_FIELD_NAME = getattr(settings, 'REST_HOOKS_OWNER_FIELD_NAME', 'user')
 
 
 class AbstractHook(models.Model):

--- a/rest_hooks/models.py
+++ b/rest_hooks/models.py
@@ -31,6 +31,8 @@ else:
     client = requests.Session()
 
 AUTH_USER_MODEL = getattr(settings, 'AUTH_USER_MODEL', 'auth.User')
+OWNER_MODEL = getattr(settings, 'REST_HOOKS_OWNER_MODEL', AUTH_USER_MODEL)
+OWNER_FIELD_NAME = getattr(settings, 'REST_HOOKS_OWNER_FIELD_NAME', 'user')
 
 
 class AbstractHook(models.Model):
@@ -40,7 +42,7 @@ class AbstractHook(models.Model):
     created = models.DateTimeField(auto_now_add=True)
     updated = models.DateTimeField(auto_now=True)
 
-    user = models.ForeignKey(AUTH_USER_MODEL, related_name='%(class)ss', on_delete=models.CASCADE)
+    user = models.ForeignKey(OWNER_MODEL, related_name='%(class)ss', on_delete=models.CASCADE)
     event = models.CharField('Event', max_length=64, db_index=True)
     target = models.URLField('Target URL', max_length=255)
 

--- a/rest_hooks/utils.py
+++ b/rest_hooks/utils.py
@@ -1,5 +1,9 @@
 from django.conf import settings
-from django.apps import apps
+try:
+    from django.apps import apps
+    get_model = apps.get_model
+except ImportError:
+    from django.db.models import get_model
 
 
 AUTH_USER_MODEL = getattr(settings, 'AUTH_USER_MODEL', 'auth.User')
@@ -55,7 +59,7 @@ def find_and_fire_hook(event_name, instance, user_override=None):
             filters['user'] = user_override
         elif hasattr(instance, 'user'):
             filters['user'] = getattr(instance, OWNER_FIELD_NAME)
-        elif isinstance(instance, apps.get_model(*OWNER_MODEL.split('.', 1))):
+        elif isinstance(instance, get_model(*OWNER_MODEL.split('.', 1))):
             filters['user'] = instance
         else:
             raise Exception(

--- a/rest_hooks/utils.py
+++ b/rest_hooks/utils.py
@@ -63,7 +63,7 @@ def find_and_fire_hook(event_name, instance, user_override=None):
             filters['user'] = instance
         else:
             raise Exception(
-                '{} has no `OWNER_MODEL.__name__` property. REST Hooks needs this.'.format(repr(instance))
+                '{} has no `{}` property. REST Hooks needs this.'.format(repr(instance), OWNER_FIELD_NAME)
             )
     # NOTE: This is probably up for discussion, but I think, in this
     # case, instead of raising an error, we should fire the hook for

--- a/rest_hooks/utils.py
+++ b/rest_hooks/utils.py
@@ -78,7 +78,7 @@ def find_and_fire_hook(event_name, instance, user_override=None):
 
 def distill_model_event(instance, model, action, user_override=None):
     """
-    Take created, updated and deleted actions for built-in
+    Take created, updated and deleted actions for built-in 
     app/model mappings, convert to the defined event.name
     and let hooks fly.
 


### PR DESCRIPTION
This demonstrates how we can easily allow configurable user / owner relation for the hooks and events. 

My specific use case is that I want hooks to be related to an Account model instead of a specific user. It has no backwards incompatible changes.