### PR TITLE
Fixes issue when using non-`auth.User` custom user model

### DIFF
--- a/rest_hooks/utils.py
+++ b/rest_hooks/utils.py
@@ -34,7 +34,11 @@ def find_and_fire_hook(event_name, instance, user_override=None):
     """
     Look up Hooks that apply
     """
-    from django.contrib.auth.models import User
+    try:
+        from django.contrib.auth import get_user_model
+        User = get_user_model()
+    except ImportError:
+        from django.contrib.auth.models import User
     from rest_hooks.models import Hook, HOOK_EVENTS
 
     if not event_name in HOOK_EVENTS.keys():
@@ -50,7 +54,7 @@ def find_and_fire_hook(event_name, instance, user_override=None):
             filters['user'] = user_override
         elif hasattr(instance, 'user'):
             filters['user'] = instance.user
-        elif isinstance(instance, User):
+        elif isinstance(instance, get_user_model()):
             filters['user'] = instance
         else:
             raise Exception(
@@ -69,7 +73,7 @@ def find_and_fire_hook(event_name, instance, user_override=None):
 
 def distill_model_event(instance, model, action, user_override=None):
     """
-    Take created, updated and deleted actions for built-in 
+    Take created, updated and deleted actions for built-in
     app/model mappings, convert to the defined event.name
     and let hooks fly.
 

--- a/rest_hooks/utils.py
+++ b/rest_hooks/utils.py
@@ -54,7 +54,7 @@ def find_and_fire_hook(event_name, instance, user_override=None):
             filters['user'] = user_override
         elif hasattr(instance, 'user'):
             filters['user'] = instance.user
-        elif isinstance(instance, get_user_model()):
+        elif isinstance(instance, User):
             filters['user'] = instance
         else:
             raise Exception(


### PR DESCRIPTION
Custom Django user models do not need to derive from `auth.User`. This PR uses `django.contrib.auth.get_user_model` in place of a direct import of `django.contrib.auth.models.User`.
