### PR TITLE
Receiver of `raw_hook_event` now uses the same logic as receivers of other signals

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ python:
   - "3.6"
 
 env:
-  - DJANGO_VERSION="1.4"
   - DJANGO_VERSION="1.5"
   - DJANGO_VERSION="1.6"
   - DJANGO_VERSION="1.7"
@@ -25,10 +24,6 @@ script: python runtests.py
 matrix:
   exclude:
     - python: "3.3"
-      env: DJANGO_VERSION="1.4"
-    - python: "3.4"
-      env: DJANGO_VERSION="1.4"
-    - python: "3.3"
       env: DJANGO_VERSION="1.9"
     - python: "3.3"
       env: DJANGO_VERSION="1.10"
@@ -36,8 +31,6 @@ matrix:
       env: DJANGO_VERSION="1.11"
     - python: "3.3"
       env: DJANGO_VERSION="2.0"
-    - python: "3.6"
-      env: DJANGO_VERSION="1.4"
     - python: "3.6"
       env: DJANGO_VERSION="1.5"
     - python: "3.6"

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -9,4 +9,10 @@ various contributors:
 
 ## Patches and Suggestions
 
-- You?
+- [Bryan Helmig](https://github.com/bryanhelmig)
+- [Arnaud Limbourg](https://github.com/arnaudlimbourg)
+- [tdruez](https://github.com/tdruez)
+- [Maina Nick](https://github.com/mainanick)
+- Jonathan Moss
+- [Erik Wickstrom](https://github.com/erikcw)
+- [Yaroslav Klyuyev](https://github.com/imposeren)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![Travis CI Build](https://img.shields.io/travis/zapier/django-rest-hooks/master.svg)](https://travis-ci.org/zapier/django-rest-hooks)
 [![PyPI Download](https://img.shields.io/pypi/v/django-rest-hooks.svg)](https://pypi.python.org/pypi/django-rest-hooks)
 [![PyPI Status](https://img.shields.io/pypi/status/django-rest-hooks.svg)](https://pypi.python.org/pypi/django-rest-hooks)
+
 ## What are Django REST Hooks?
 
 
@@ -32,6 +33,53 @@ If you want to make a Django form or API resource, you'll need to do that yourse
 (though we've provided some example bits of code below).
 
 
+### Changelog
+
+#### Version 1.6.0:
+
+Improvements:
+
+* Default handler of `raw_hook_event` uses the same logic as other handlers
+  (see "Backwards incompatible changes" for details).
+
+* Lookup of event_name by model+action_name now has a complexity of `O(1)`
+  instead of `O(len(settings.HOOK_EVENTS))`
+
+* `HOOK_CUSTOM_MODEL` is now similar to `AUTH_USER_MODEL`: must be of the form
+  `app_label.model_name` (for django 1.7+). If old value is of the form
+  `app_label.models.model_name` then it's automatically adapted.
+
+* `rest_hooks.models.Hook` is now really "swappable", so table creation is
+  skipped if you have different `settings.HOOK_CUSTOM_MODEL`
+
+* `rest_hooks.models.AbstractHook.deliver_hook` now accepts a callable as
+  `payload_override` argument (must accept 2 arguments: hook, instance). This
+  was added to support old behavior of `raw_custom_event`.
+
+Fixes:
+
+* HookAdmin.form now honors `settings.HOOK_CUSTOM_MODEL`
+
+* event_name determined from action+model is now consistent between runs (see
+  "Backwards incompatible changes")
+
+Backwards incompatible changes:
+
+* Dropped support for django 1.4
+* Custom `HOOK_FINDER`-s should accept and handle new argument `payload_override`.
+  Built-in finder `rest_hooks.utls.find_and_fire_hook` already does this.
+* If several event names in `settings.HOOK_EVENTS` share the same
+  `'app_label.model.action'` (including `'app_label.model.action+'`) then
+  `django.core.exceptions.ImproperlyConfigured` is raised
+* Receiver of `raw_hook_event` now uses the same logic as receivers of other
+  signals: checks event_name against settings.HOOK_EVENTS, verifies model (if
+  instance is passed), uses `HOOK_FINDER`. Old behaviour can be achieved by
+  using `trust_event_name=True`, or `instance=None` to fire a signal.
+* If you have `settings.HOOK_CUSTOM_MODEL` of the form different than
+  `app_label.models.model_name` or `app_label.model_name`, then it must
+  be changed to `app_label.model_name`.
+
+
 ### Development
 
 Running the tests for Django REST Hooks is very easy, just:
@@ -57,7 +105,7 @@ python runtests.py
 ### Requirements
 
 * Python 2 or 3 (tested on 2.7, 3.3, 3.4, 3.6)
-* Django 1.4+ (tested on 1.5, 1.6, 1.7, 1.8, 1.9, 1.10, 1.11, 2.0)
+* Django 1.5+ (tested on 1.5, 1.6, 1.7, 1.8, 1.9, 1.10, 1.11, 2.0)
 
 ### Installing & Configuring
 

--- a/devrequirements_1.4.txt
+++ b/devrequirements_1.4.txt
@@ -1,2 +1,0 @@
--r devrequirements.txt
-Django>=1.4.6,<1.5

--- a/devrequirements_1.8.txt
+++ b/devrequirements_1.8.txt
@@ -1,3 +1,3 @@
 -r devrequirements.txt
-django-contrib-comments>=1.6.1
+django-contrib-comments>=1.6.1,<1.7.0
 Django>=1.8,<1.9

--- a/devrequirements_1.9.txt
+++ b/devrequirements_1.9.txt
@@ -1,3 +1,3 @@
 -r devrequirements.txt
-django-contrib-comments>=1.6.2
+django-contrib-comments>=1.6.2,<1.7.0
 Django>=1.9,<1.10

--- a/rest_hooks/__init__.py
+++ b/rest_hooks/__init__.py
@@ -1,1 +1,1 @@
-VERSION = (1, 5, 0)
+VERSION = (1, 6, 0)

--- a/rest_hooks/admin.py
+++ b/rest_hooks/admin.py
@@ -1,12 +1,13 @@
 from django.contrib import admin
 from django.conf import settings
 from django import forms
-from rest_hooks.models import Hook
+from rest_hooks.utils import get_hook_model
 
-
-HOOK_EVENTS = getattr(settings, 'HOOK_EVENTS', None)
-if HOOK_EVENTS is None:
+if getattr(settings, 'HOOK_EVENTS', None) is None:
     raise Exception("You need to define settings.HOOK_EVENTS!")
+
+
+HookModel = get_hook_model()
 
 
 class HookForm(forms.ModelForm):
@@ -15,20 +16,24 @@ class HookForm(forms.ModelForm):
     only events declared on HOOK_EVENTS settings
     can be registered.
     """
-    ADMIN_EVENTS = [(x, x) for x in HOOK_EVENTS.keys()]
 
     class Meta:
-        model = Hook
+        model = HookModel
         fields = ['user', 'target', 'event']
 
     def __init__(self, *args, **kwargs):
         super(HookForm, self).__init__(*args, **kwargs)
-        self.fields['event'] = forms.ChoiceField(choices=self.ADMIN_EVENTS)
+        self.fields['event'] = forms.ChoiceField(choices=self.get_admin_events())
+
+    @classmethod
+    def get_admin_events(cls):
+        return [(x, x) for x in getattr(settings, 'HOOK_EVENTS', None).keys()]
 
 
 class HookAdmin(admin.ModelAdmin):
-    list_display = [f.name for f in Hook._meta.fields]
+    list_display = [f.name for f in HookModel._meta.fields]
     raw_id_fields = ['user', ]
     form = HookForm
 
-admin.site.register(Hook, HookAdmin)
+
+admin.site.register(HookModel, HookAdmin)

--- a/rest_hooks/migrations/0001_initial.py
+++ b/rest_hooks/migrations/0001_initial.py
@@ -24,6 +24,7 @@ class Migration(migrations.Migration):
                 ('user', models.ForeignKey(related_name='hooks', to=settings.AUTH_USER_MODEL, on_delete=django.db.models.deletion.CASCADE)),
             ],
             options={
+                'swappable': 'HOOK_CUSTOM_MODEL',
             },
             bases=(models.Model,),
         ),

--- a/rest_hooks/migrations/0002_swappable_hook_model.py
+++ b/rest_hooks/migrations/0002_swappable_hook_model.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('rest_hooks', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='Hook',
+            options={
+                'swappable': 'HOOK_CUSTOM_MODEL',
+            },
+        ),
+    ]

--- a/rest_hooks/utils.py
+++ b/rest_hooks/utils.py
@@ -1,4 +1,16 @@
+import django
+
+try:
+    from django.apps import apps as django_apps
+except ImportError:
+    django_apps = None
+from django.core.exceptions import ImproperlyConfigured
 from django.conf import settings
+
+if django.VERSION >= (2, 0,):
+    get_model_kwargs = {'require_ready': False}
+else:
+    get_model_kwargs = {}
 
 
 def get_module(path):
@@ -29,19 +41,39 @@ def get_module(path):
 
     return func
 
+
 def get_hook_model():
     """
     Returns the Custom Hook model if defined in settings,
     otherwise the default Hook model.
     """
-    from rest_hooks.models import Hook
-    HookModel = Hook
-    if getattr(settings, 'HOOK_CUSTOM_MODEL', None):
-        HookModel = get_module(settings.HOOK_CUSTOM_MODEL)
-    return HookModel
+    model_label = getattr(settings, 'HOOK_CUSTOM_MODEL', None)
+    if django_apps:
+        model_label = (model_label or 'rest_hooks.Hook').replace('.models.', '.')
+        try:
+            return django_apps.get_model(model_label, **get_model_kwargs)
+        except ValueError:
+            raise ImproperlyConfigured("HOOK_CUSTOM_MODEL must be of the form 'app_label.model_name'")
+        except LookupError:
+            raise ImproperlyConfigured(
+                "HOOK_CUSTOM_MODEL refers to model '%s' that has not been installed" % model_label
+            )
+    else:
+        if model_label in (None, 'rest_hooks.Hook'):
+            from rest_hooks.models import Hook
+            HookModel = Hook
+        else:
+            try:
+                HookModel = get_module(settings.HOOK_CUSTOM_MODEL)
+            except ImportError:
+                raise ImproperlyConfigured(
+                    "HOOK_CUSTOM_MODEL refers to model '%s' that cannot be imported" % model_label
+                )
+        return HookModel
 
 
-def find_and_fire_hook(event_name, instance, user_override=None):
+
+def find_and_fire_hook(event_name, instance, user_override=None, payload_override=None):
     """
     Look up Hooks that apply
     """
@@ -52,7 +84,7 @@ def find_and_fire_hook(event_name, instance, user_override=None):
         from django.contrib.auth.models import User
     from rest_hooks.models import HOOK_EVENTS
 
-    if not event_name in HOOK_EVENTS.keys():
+    if event_name not in HOOK_EVENTS.keys():
         raise Exception(
             '"{}" does not exist in `settings.HOOK_EVENTS`.'.format(event_name)
         )
@@ -81,32 +113,67 @@ def find_and_fire_hook(event_name, instance, user_override=None):
 
     hooks = HookModel.objects.filter(**filters)
     for hook in hooks:
-        hook.deliver_hook(instance)
+        hook.deliver_hook(instance, payload_override=payload_override)
 
 
-def distill_model_event(instance, model, action, user_override=None):
+def distill_model_event(
+        instance,
+        model=False,
+        action=False,
+        user_override=None,
+        event_name=False,
+        trust_event_name=False,
+        payload_override=None,
+        ):
     """
-    Take created, updated and deleted actions for built-in
-    app/model mappings, convert to the defined event.name
-    and let hooks fly.
+    Take `event_name` or determine it using action and model
+    from settings.HOOK_EVENTS, and let hooks fly.
 
-    If that model isn't represented, we just quit silenty.
+    if `event_name` is passed together with `model` or `action`, then
+    they should be the same as in settings or `trust_event_name` should be
+    `True`
+
+    If event_name is not found or is invalidated, then just quit silently.
+
+    If payload_override is passed, then it will be passed into HookModel.deliver_hook
+
     """
-    from rest_hooks.models import HOOK_EVENTS
+    from rest_hooks.models import get_event_actions_config, HOOK_EVENTS
 
-    event_name = None
-    for maybe_event_name, auto in HOOK_EVENTS.items():
-        if auto:
-            # break auto into App.Model, Action
-            maybe_model, maybe_action = auto.rsplit('.', 1)
-            maybe_action = maybe_action.rsplit('+', 1)
-            if model == maybe_model and action == maybe_action[0]:
-                event_name = maybe_event_name
-                if len(maybe_action) == 2:
+    if event_name is False and (model is False or action is False):
+        raise TypeError(
+            'distill_model_event() requires either `event_name` argument or '
+            'both `model` and `action` arguments.'
+        )
+    if event_name:
+        if trust_event_name:
+            pass
+        elif event_name in HOOK_EVENTS:
+            auto = HOOK_EVENTS[event_name]
+            if auto:
+                allowed_model, allowed_action = auto.rsplit('.', 1)
+
+                allowed_action_parts = allowed_action.rsplit('+', 1)
+                allowed_action = allowed_action_parts[0]
+
+                model = model or allowed_model
+                action = action or allowed_action
+
+                if not (model == allowed_model and action == allowed_action):
+                    event_name = None
+
+                if len(allowed_action_parts) == 2:
                     user_override = False
+    else:
+        event_actions_config = get_event_actions_config()
+
+        event_name, ignore_user_override = event_actions_config.get(model, {}).get(action, (None, False))
+        if ignore_user_override:
+            user_override = False
 
     if event_name:
-        finder = find_and_fire_hook
         if getattr(settings, 'HOOK_FINDER', None):
             finder = get_module(settings.HOOK_FINDER)
-        finder(event_name, instance, user_override=user_override)
+        else:
+            finder = find_and_fire_hook
+        finder(event_name, instance, user_override=user_override, payload_override=payload_override)

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     author = 'Bryan Helmig',
     author_email = 'bryan@zapier.com',
     url = 'http://github.com/zapier/django-rest-hooks',
-    install_requires=['Django>=1.4','requests'],
+    install_requires=['Django>=1.5', 'requests'],
     packages=['rest_hooks'],
     package_data={
         'rest_hooks': [


### PR DESCRIPTION
Should solve #58

Some backward incompatible changes were introduced (see README.md)