### PR TITLE
[DRH-1]: Add Power Support ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,14 @@
 language: python
 
+arch:
+  - amd64
+  - ppc64le
+
 python:
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.6"
+  - "3.8"
 
 env:
   - DJANGO_VERSION="1.5"
@@ -23,14 +27,6 @@ script: python runtests.py
 
 matrix:
   exclude:
-    - python: "3.3"
-      env: DJANGO_VERSION="1.9"
-    - python: "3.3"
-      env: DJANGO_VERSION="1.10"
-    - python: "3.3"
-      env: DJANGO_VERSION="1.11"
-    - python: "3.3"
-      env: DJANGO_VERSION="2.0"
     - python: "3.6"
       env: DJANGO_VERSION="1.5"
     - python: "3.6"
@@ -39,6 +35,19 @@ matrix:
       env: DJANGO_VERSION="1.7"
     - python: "2.7"
       env: DJANGO_VERSION="2.0"
+    - python: "3.8"
+      env: DJANGO_VERSION="1.5"
+    - python: "3.8"
+      env: DJANGO_VERSION="1.6"
+    - python: "3.8"
+      env: DJANGO_VERSION="1.7"
+    - python: "3.8"
+      env: DJANGO_VERSION="1.8"
+    - python: "3.8"
+      env: DJANGO_VERSION="1.9"
+    - python: "3.8"
+      env: DJANGO_VERSION="1.10"
+      
 
 before_deploy:
   - pip install wheel


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing.