### PR TITLE
[DRH-3]: Fix import for celery 5.0

### DIFF
--- a/rest_hooks/tasks.py
+++ b/rest_hooks/tasks.py
@@ -1,7 +1,11 @@
 import requests
 import json
 
-from celery.task import Task
+try:
+    from celery import Task
+except ImportError:
+    # Available in celery versions before 5.0.
+    from celery.task import Task
 
 from django.core.serializers.json import DjangoJSONEncoder
 


### PR DESCRIPTION
Celery 5.0 no longer contains the `celery.task` module.  The `Task` class has been moved into the `celery` namespace.